### PR TITLE
Added a way to read the `pylint` score inside `PEP8TestCase` 

### DIFF
--- a/src/tac/perf_test_case.py
+++ b/src/tac/perf_test_case.py
@@ -66,7 +66,7 @@ class PEP8TestCase(TestCase):
         else:
             return None, None
 
-    def run(self, method: str):
+    def run(self, method: str = "pylint"):
         assert method in self.methods, f"{method} is not implemented yet, please choose between: {self.methods}"
         run_method_command = self._method_commands[method]
         percent_value, message = run_method_command()

--- a/src/tac/perf_test_case.py
+++ b/src/tac/perf_test_case.py
@@ -53,7 +53,7 @@ class PEP8TestCase(TestCase):
         output = StringIO()
         sys.stdout = output
         try:
-            Run([self.files_dir, '--exit-zero'])
+            Run([self.files_dir, f'--max-line-length={self.MAX_LINE_LENGTH}', '--exit-zero'])
         except SystemExit:
             pass
         sys.stdout = sys.__stdout__

--- a/src/tac/perf_test_case.py
+++ b/src/tac/perf_test_case.py
@@ -1,5 +1,10 @@
+import sys
+import re
+from io import StringIO
+
 import numpy as np
 import pycodestyle
+from pylint.lint import Run
 
 
 class TestResult:
@@ -23,12 +28,17 @@ class TestCase:
 
 class PEP8TestCase(TestCase):
     MAX_LINE_LENGTH = 120
+    methods = {"pycodestyle", "pylint"}
     
     def __init__(self, name: str, files_dir: str):
         self.name = name
         self.files_dir = files_dir
-    
-    def run(self):
+        self._method_commands = {
+            "pycodestyle": self._run_pycodestyle,
+            "pylint": self._run_pylint,
+        }
+
+    def _run_pycodestyle(self):
         pep8style = pycodestyle.StyleGuide(ignore="W191,E501", max_line_length=self.MAX_LINE_LENGTH, quiet=True)
         result = pep8style.check_files([self.files_dir])
         message = ', '.join(set([f"{key}:'{err_msg}'" for key, err_msg in result.messages.items()]))
@@ -37,4 +47,27 @@ class PEP8TestCase(TestCase):
         else:
             err_ratio = result.total_errors / result.counters['physical lines']
         percent_value = np.clip(100.0 - (err_ratio * 100.0), 0.0, 100.0).item()
+        return percent_value, message # TestResult(self.name, percent_value, message=message)
+
+    def _run_pylint(self):
+        output = StringIO()
+        sys.stdout = output
+        try:
+            Run([self.files_dir, '--exit-zero'])
+        except SystemExit:
+            pass
+        sys.stdout = sys.__stdout__
+        pylint_output = output.getvalue()
+        match = re.search(r"Your code has been rated at ([\d\.]+)/10", pylint_output)
+        if match:
+            score = float(match.group(1))
+            percent_value = 10 * score
+            return percent_value, None # TestResult(self.name, score, message=None)
+        else:
+            return None, None
+
+    def run(self, method: str):
+        assert method in self.methods, f"{method} is not implemented yet, please choose between: {self.methods}"
+        run_method_command = self._method_commands[method]
+        percent_value, message = run_method_command()
         return TestResult(self.name, percent_value, message=message)


### PR DESCRIPTION
Added a way to use either `pylint` or `pycodestyle` to score a homework code writing style with PEP8. I specified the variable `method` to be `"pylint"` inside the `PEP8TestCase`  class because I didn't want to modify the whole pipeline of the package by adding a new argument.